### PR TITLE
Refactor of setting background color and some sweet fixes

### DIFF
--- a/build/css/style.css
+++ b/build/css/style.css
@@ -16,12 +16,8 @@ body {
   left: 0;
   top: 0;
   bottom: 0;
-  transition: left 0.5s;
-  overflow-y: scroll;
-  overflow-x: hidden;
-  -webkit-perspective: 1px;
-  perspective: 1px;
-  transition: background-color 0.5s; }
+  transition: left 0.5s, background-color 0.5s;
+  overflow: hidden; }
   .app-contest__header {
     margin-bottom: 48px; }
   .app-contest__content {
@@ -37,14 +33,23 @@ body {
     -ms-flex-negative: 0;
     flex-shrink: 0;
     padding: 45px 30px 30px;
-    background-color: #fff; }
+    background-color: #fff;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    -webkit-perspective: 1px;
+    perspective: 1px; }
     .app-contest__slide--colored {
       background-color: inherit; }
   .app-contest__action {
     margin-top: 48px; }
-  .app-contest__answer--correct {
-    background-color: #ffffff;
-    border-radius: 12px; }
+  .app-contest__answer {
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    padding: 8px; }
+    .app-contest__answer--correct {
+      background-color: #ffffff;
+      border-radius: 20px; }
   .app-contest__footer {
     margin-top: 24px; }
   .app-contest__results td, .app-contest__results th {
@@ -56,10 +61,9 @@ body {
     -ms-flex-align: center;
     -ms-grid-row-align: center;
     align-items: center; }
-  .app-contest .mint-label {
-    margin-bottom: 12px; }
   .app-contest .mint-label--secondary .mint-label__text {
-    color: #000; }
+    color: #000;
+    width: 100%; }
   .app-contest .mint-header-secondary {
     font-size: 1.5rem;
     line-height: 1.5rem;

--- a/build/css/style.css
+++ b/build/css/style.css
@@ -6,8 +6,7 @@ body {
   top: 0;
   bottom: 0;
   position: fixed;
-  overflow: hidden;
-  transition: background-color 0.5s; }
+  overflow: hidden; }
 
 .app-contest {
   display: -webkit-flex;
@@ -21,7 +20,8 @@ body {
   overflow-y: scroll;
   overflow-x: hidden;
   -webkit-perspective: 1px;
-  perspective: 1px; }
+  perspective: 1px;
+  transition: background-color 0.5s; }
   .app-contest__header {
     margin-bottom: 48px; }
   .app-contest__content {
@@ -36,7 +36,10 @@ body {
     -webkit-flex-shrink: 0;
     -ms-flex-negative: 0;
     flex-shrink: 0;
-    padding: 45px 30px 30px; }
+    padding: 45px 30px 30px;
+    background-color: #fff; }
+    .app-contest__slide--colored {
+      background-color: inherit; }
   .app-contest__action {
     margin-top: 48px; }
   .app-contest__answer--correct {
@@ -55,6 +58,8 @@ body {
     align-items: center; }
   .app-contest .mint-label {
     margin-bottom: 12px; }
+  .app-contest .mint-label--secondary .mint-label__text {
+    color: #000; }
   .app-contest .mint-header-secondary {
     font-size: 1.5rem;
     line-height: 1.5rem;

--- a/build/js/build.js
+++ b/build/js/build.js
@@ -158,7 +158,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Question = function Question(props) {
     var votes = props.votes;
     var question = props.question;
-    var backgroundStyle = props.backgroundStyle;
     var answerNodes = question.answers.map(function (answer) {
         return _react2.default.createElement(_answer2.default, { answer: answer, questionId: question.id, user: props.user, votes: votes, key: answer.id });
     });
@@ -170,7 +169,7 @@ var Question = function Question(props) {
 
     return _react2.default.createElement(
         'div',
-        { className: 'app-contest__slide', style: backgroundStyle },
+        { className: 'app-contest__slide app-contest__slide--colored' },
         _react2.default.createElement(
             'div',
             { className: 'app-contest__question' },
@@ -397,6 +396,8 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var backgroundColors = ['#6ed6a0', '#5bb8ff', '#6e85ff', '#ff8073', '#ffbe32'];
+
 var SlideList = function (_React$Component) {
     _inherits(SlideList, _React$Component);
 
@@ -466,8 +467,10 @@ var SlideList = function (_React$Component) {
             var slide = arguments.length <= 0 || arguments[0] === undefined ? 0 : arguments[0];
 
             var slideIndex = parseInt(slide, 10);
+
             this.style = {
-                left: -(slideIndex * 100) + 'vw'
+                left: -(slideIndex * 100) + 'vw',
+                backgroundColor: this.getBackgroundColor()
             };
 
             this.setState({
@@ -555,13 +558,16 @@ var SlideList = function (_React$Component) {
             this.votesRepo.onError(this.showError.bind(this));
         }
     }, {
-        key: 'getBackgroundStyle',
-        value: function getBackgroundStyle(index) {
-            var colors = ['#a7e6c6', '#abe3ff', '#fdc7c1', '#ffdb8d', '#bdc8fc'];
+        key: 'getBackgroundColor',
+        value: function getBackgroundColor() {
+            var backgroundColor = backgroundColors[Math.floor(Math.random() * backgroundColors.length)];
 
-            return {
-                backgroundColor: colors[index % colors.length]
-            };
+            if (this.currentBackgroundColor !== backgroundColor) {
+                this.currentBackgroundColor = backgroundColor;
+                return this.currentBackgroundColor;
+            }
+
+            return this.getBackgroundColor();
         }
     }, {
         key: 'handleLoginClick',
@@ -580,8 +586,7 @@ var SlideList = function (_React$Component) {
                     user: _this6.user,
                     votes: _this6.votesRepo,
                     showVoters: _this6.user.isAdmin(),
-                    key: question.id,
-                    backgroundStyle: _this6.getBackgroundStyle(question.id) });
+                    key: question.id });
             });
 
             var solutionNodes = [];
@@ -591,8 +596,7 @@ var SlideList = function (_React$Component) {
                         question: question,
                         user: _this6.user,
                         votes: _this6.votesRepo,
-                        key: question.id,
-                        backgroundStyle: _this6.getBackgroundStyle(question.id) });
+                        key: question.id });
                 });
             }
 
@@ -637,7 +641,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Solution = function Solution(props) {
     var votes = props.votes;
     var question = props.question;
-    var backgroundStyle = props.backgroundStyle;
     var answerNodes = question.answers.map(function (answer) {
         var voters = props.votes.getVotersForAnswer(question.id, answer.id);
 
@@ -654,7 +657,7 @@ var Solution = function Solution(props) {
 
     return _react2.default.createElement(
         'div',
-        { className: 'app-contest__slide', style: backgroundStyle },
+        { className: 'app-contest__slide app-contest__slide--colored' },
         _react2.default.createElement(
             'div',
             { className: 'app-contest__question' },

--- a/build/js/build.js
+++ b/build/js/build.js
@@ -176,6 +176,8 @@ var Question = function Question(props) {
             _react2.default.createElement(
                 'h1',
                 { className: 'mint-header-secondary' },
+                question.id + 1,
+                '. ',
                 props.question.text
             ),
             _react2.default.createElement(
@@ -664,6 +666,8 @@ var Solution = function Solution(props) {
             _react2.default.createElement(
                 'h1',
                 { className: 'mint-header-secondary' },
+                question.id + 1,
+                '. ',
                 props.question.text
             ),
             _react2.default.createElement(

--- a/js/components/question.js
+++ b/js/components/question.js
@@ -4,7 +4,6 @@ import Answer from '../components/answer.js';
 const Question = (props) => {
     const votes = props.votes;
     const question = props.question;
-    const backgroundStyle = props.backgroundStyle;
     const answerNodes = question.answers.map((answer)  => {
         return (
             <Answer answer={answer} questionId={question.id} user={props.user} votes={votes} key={answer.id}/>
@@ -17,7 +16,7 @@ const Question = (props) => {
     }
 
     return (
-        <div className="app-contest__slide" style={backgroundStyle}>
+        <div className="app-contest__slide app-contest__slide--colored">
             <div className="app-contest__question">
                 <h1 className="mint-header-secondary">
                     {props.question.text}

--- a/js/components/question.js
+++ b/js/components/question.js
@@ -19,7 +19,7 @@ const Question = (props) => {
         <div className="app-contest__slide app-contest__slide--colored">
             <div className="app-contest__question">
                 <h1 className="mint-header-secondary">
-                    {props.question.text}
+                    {question.id + 1}. {props.question.text}
                 </h1>
 
                 <div className="app-content_answers">

--- a/js/components/slideList.js
+++ b/js/components/slideList.js
@@ -11,6 +11,14 @@ import VotesRepository from '../votes-repository';
 import User from '../user';
 import SlideController from '../slide-controller';
 
+const backgroundColors = [
+    '#6ed6a0',
+    '#5bb8ff',
+    '#6e85ff',
+    '#ff8073',
+    '#ffbe32'
+];
+
 class SlideList extends React.Component{
     constructor() {
         super();
@@ -66,8 +74,10 @@ class SlideList extends React.Component{
 
     goToSlide(slide = 0) {
         const slideIndex = parseInt(slide, 10);
+
         this.style = {
-            left: -(slideIndex * 100) + 'vw'
+            left: -(slideIndex * 100) + 'vw',
+            backgroundColor: this.getBackgroundColor()
         };
 
         this.setState({
@@ -141,18 +151,16 @@ class SlideList extends React.Component{
         this.votesRepo.onError(this.showError.bind(this));
     }
 
-    getBackgroundStyle(index) {
-        const colors = [
-            '#a7e6c6',
-            '#abe3ff',
-            '#fdc7c1',
-            '#ffdb8d',
-            '#bdc8fc'
-        ];
+    getBackgroundColor() {
+        const backgroundColor = backgroundColors[Math.floor(Math.random() * backgroundColors.length )];
 
-        return {
-            backgroundColor: colors[index % colors.length ]
-        };
+        if ( this.currentBackgroundColor !== backgroundColor ) {
+            this.currentBackgroundColor = backgroundColor;
+            return this.currentBackgroundColor;
+        }
+
+        return this.getBackgroundColor();
+
     }
 
     handleLoginClick() {
@@ -168,8 +176,7 @@ class SlideList extends React.Component{
                     user={this.user}
                     votes={this.votesRepo}
                     showVoters={this.user.isAdmin()}
-                    key={question.id}
-                    backgroundStyle={this.getBackgroundStyle(question.id)}/>
+                    key={question.id}/>
             );
         });
 
@@ -181,8 +188,7 @@ class SlideList extends React.Component{
                         question={question}
                         user={this.user}
                         votes={this.votesRepo}
-                        key={question.id}
-                        backgroundStyle={this.getBackgroundStyle(question.id)}/>
+                        key={question.id}/>
                 );
             })
         }

--- a/js/components/solution.js
+++ b/js/components/solution.js
@@ -24,7 +24,7 @@ const Solution = (props) => {
         <div className="app-contest__slide app-contest__slide--colored">
             <div className="app-contest__question">
                 <h1 className="mint-header-secondary">
-                    {props.question.text}
+                    {question.id + 1}. {props.question.text}
                 </h1>
 
                 <div className="app-content_answers">

--- a/js/components/solution.js
+++ b/js/components/solution.js
@@ -4,7 +4,6 @@ import Answer from '../components/answer.js';
 const Solution = (props) => {
     const votes = props.votes;
     const question = props.question;
-    const backgroundStyle = props.backgroundStyle;
     const answerNodes = question.answers.map((answer)  => {
         const voters = props.votes.getVotersForAnswer(question.id, answer.id);
 
@@ -22,7 +21,7 @@ const Solution = (props) => {
     });
 
     return (
-        <div className="app-contest__slide" style={backgroundStyle}>
+        <div className="app-contest__slide app-contest__slide--colored">
             <div className="app-contest__question">
                 <h1 className="mint-header-secondary">
                     {props.question.text}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -15,11 +15,8 @@ body {
   left: 0;
   top: 0;
   bottom: 0;
-  transition: left 0.5s;
-  overflow-y: scroll;
-  overflow-x: hidden;
-  perspective: 1px; //FIX for Chrome bug making avatars square
-  transition: background-color 0.5s;
+  transition: left 0.5s, background-color 0.5s;
+  overflow: hidden;
 
   &__header {
     margin-bottom: 48px;
@@ -39,6 +36,9 @@ body {
     flex-shrink: 0;
     padding: 45px 30px 30px;
     background-color: #fff;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    perspective: 1px; //FIX for Chrome bug making avatars square
 
     &--colored {
       background-color: inherit;
@@ -50,9 +50,12 @@ body {
   }
 
   &__answer {
+    display: flex;
+    padding: 8px;
+
     &--correct {
       background-color: #ffffff;
-      border-radius: 12px;
+      border-radius: 20px;
     }
   }
 
@@ -74,12 +77,9 @@ body {
     align-items: center;
   }
 
-  .mint-label {
-    margin-bottom: 12px;
-  }
-
   .mint-label--secondary .mint-label__text {
     color: #000;
+    width: 100%;
   }
 
   .mint-header-secondary {

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -7,7 +7,6 @@ body {
   bottom: 0;
   position: fixed;
   overflow: hidden;
-  transition: background-color 0.5s;
 }
 
 .app-contest {
@@ -20,6 +19,7 @@ body {
   overflow-y: scroll;
   overflow-x: hidden;
   perspective: 1px; //FIX for Chrome bug making avatars square
+  transition: background-color 0.5s;
 
   &__header {
     margin-bottom: 48px;
@@ -38,6 +38,11 @@ body {
     width: 100vw;
     flex-shrink: 0;
     padding: 45px 30px 30px;
+    background-color: #fff;
+
+    &--colored {
+      background-color: inherit;
+    }
   }
 
   &__action {
@@ -71,6 +76,10 @@ body {
 
   .mint-label {
     margin-bottom: 12px;
+  }
+
+  .mint-label--secondary .mint-label__text {
+    color: #000;
   }
 
   .mint-header-secondary {


### PR DESCRIPTION
- bg colors

![app](https://cloud.githubusercontent.com/assets/1231144/13303301/c69f8576-db4e-11e5-848f-d0b33bc5e4c3.gif)

- issue with the empty white space below the question slides when the slide with results is too long. (https://github.com/brainly/datacontest/issues/13)
- `width: 100%` for label to make it easier to tap on mobile devices
- numbering of questions/solutions
- improved appearance of the correct answer:

<img width="321" alt="screen shot 2016-02-25 at 00 09 57" src="https://cloud.githubusercontent.com/assets/1231144/13304341/5791c7c4-db54-11e5-9c48-fca8169cdcf8.png">


@kdzwinel 